### PR TITLE
small performance improvment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ eframe = "0.33"
 egui_extras = { version = "0.33", features = ["default"] }
 rfd = "0.15"
 jwalk = "0.8"
-blake3 = { version = "1", features = ["pure"] }
+blake3 = { version = "1", features = ["prefer_intrinsics"] }
 crossbeam-channel = "0.5"
 anyhow = "1"
 

--- a/src/scanner/duplicates.rs
+++ b/src/scanner/duplicates.rs
@@ -269,7 +269,7 @@ fn full_hash_with_progress(
 ) -> std::io::Result<[u8; 32]> {
     let mut file = File::open(path)?;
     let mut hasher = blake3::Hasher::new();
-    let mut buf = [0u8; 8192];
+    let mut buf = [0u8; 512 * 1024];
     loop {
         let n = file.read(&mut buf)?;
         if n == 0 {


### PR DESCRIPTION
## Summary by Sourcery

Improve file hashing performance in the duplicate scanner by tuning hashing configuration and I/O buffering.

Enhancements:
- Increase the file read buffer size used during full hash computation to reduce I/O overhead.
- Switch the blake3 dependency to prefer intrinsic-based optimizations for faster hashing.